### PR TITLE
Move inline styles to CSS for heroes section

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -72,3 +72,37 @@
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
+
+/* Hero Name Styles */
+.p-home__hero--name {
+  color: #edbe80;
+  font-family: UTM Helve;
+  font-size: 26.0438px;
+  font-weight: 700;
+  line-height: 28.6481px;
+  margin: 0px 0px 16.205px;
+  text-align: left;
+}
+
+/* Hero Role P Tag Styles */
+.p-home__hero--role p {
+  color: #fff;
+  font-family: UTM Helve;
+  font-size: 14.4687px;
+  line-height: 17.3625px;
+  margin: 0px 0px 0px 9.26px;
+  text-align: left;
+}
+
+/* Hero List Styles */
+@media (min-width: 750px) {
+  .p-home__heroes--list {
+    bottom: 51rem;
+    right: 213rem;
+  }
+}
+
+.p-home__heroes--list {
+  display: flex;
+  position: absolute;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -44,7 +44,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: url(./../img/bg-home-heroes.jpg) 0 0 / 100% 100% no-repeat;
   }
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,35 @@
     transform: rotate(360deg);
   }
 }
+
+/* Heroes Section Styles */
+@media (min-width: 750px) {
+  .p-home__heroes--title {
+    height: 224rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: url(./../img/bg-home-heroes.jpg) 0 0 / 100% 100% no-repeat;
+  }
+}
+
+.p-home__heroes--title {
+  width: 100%;
+}
+
+.title {
+  font-size: 52rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  position: relative;
+  display: block;
+  text-align: center;
+  line-height: 1.4em;
+  padding-bottom: 32rem;
+  background: #fce3bc;
+  background: -webkit-linear-gradient(to top, #bd9867 0%, #fce3bc 100%);
+  background: -moz-linear-gradient(to top, #bd9867 0%, #fce3bc 100%);
+  background: linear-gradient(to top, #bd9867 0%, #fce3bc 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0);
+}

--- a/src/App.css
+++ b/src/App.css
@@ -38,32 +38,33 @@
 }
 
 /* Heroes Section Styles */
-@media (min-width: 750px) {
-  .p-home__heroes--title {
-    height: 224rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-}
-
 .p-home__heroes--title {
-  width: 100%;
+  align-items: center;
+  background-image: url("https://lienquan.garena.vn/wp-content/themes/aov-2024/assets/img/bg-home-heroes.jpg");
+  background-position: 0px 0px;
+  background-size: 100% 100%;
+  display: flex;
+  font-family: UTM Helve;
+  font-size: 1.1575px;
+  font-weight: 500;
+  justify-content: center;
+  line-height: 1.389px;
+  margin: 0px 0px 0.289375px;
+  text-align: left;
 }
 
 .title {
-  font-size: 52rem;
+  background-image: linear-gradient(
+    to top,
+    rgb(189, 152, 103) 0%,
+    rgb(252, 227, 188) 100%
+  );
+  font-size: 30.095px;
   font-weight: 700;
-  text-transform: uppercase;
-  position: relative;
-  display: block;
+  line-height: 42.133px;
+  padding: 0px 0px 18.52px;
   text-align: center;
-  line-height: 1.4em;
-  padding-bottom: 32rem;
-  background: #fce3bc;
-  background: -webkit-linear-gradient(to top, #bd9867 0%, #fce3bc 100%);
-  background: -moz-linear-gradient(to top, #bd9867 0%, #fce3bc 100%);
-  background: linear-gradient(to top, #bd9867 0%, #fce3bc 100%);
+  text-transform: uppercase;
   -webkit-background-clip: text;
-  -webkit-text-fill-color: rgba(0, 0, 0, 0);
+  -webkit-text-fill-color: transparent;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -43,6 +43,7 @@
   background-image: url("https://lienquan.garena.vn/wp-content/themes/aov-2024/assets/img/bg-home-heroes.jpg");
   background-position: 0px 0px;
   background-size: 100% 100%;
+  background-repeat: no-repeat;
   display: flex;
   font-family: UTM Helve;
   font-size: 1.1575px;
@@ -51,6 +52,8 @@
   line-height: 1.389px;
   margin: 0px 0px 0.289375px;
   text-align: left;
+  height: 200px;
+  width: 100%;
 }
 
 .title {
@@ -67,4 +70,5 @@
   text-transform: uppercase;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+  background-clip: text;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -810,23 +810,9 @@ const ChampionSection = () => {
 const HeroesSection = () => {
   return (
     <section className="p-home__heroes">
-      <h2 className="p-home__heroes--title">
-        <span
-          className="title"
-          style={{
-            backgroundImage:
-              "linear-gradient(to top, rgb(189, 152, 103) 0%, rgb(252, 227, 188) 100%)",
-            fontSize: "30.095px",
-            fontWeight: "700",
-            lineHeight: "42.133px",
-            padding: "0px 0px 18.52px",
-            textAlign: "center",
-            textTransform: "uppercase",
-          }}
-        >
-          TƯỚNG & TRANG PHỤC ĐA DẠNG
-        </span>
-      </h2>
+      <div className="p-home__heroes--title">
+        <span className="title">TƯỚNG & TRANG PHỤC ĐA DẠNG</span>
+      </div>
       <div className="p-home__heroes--main">
         <ul className="p-home__heroes--content">
           <li className="p-home__hero" id="hero-1">


### PR DESCRIPTION
This pull request refactors the heroes section styling by moving inline styles to external CSS.

Changes made:
- Moved inline styles from the title span element to CSS classes in App.css
- Changed h2 element to div element for the heroes title container
- Added comprehensive CSS styles for heroes section including:
  - .p-home__heroes--title with background image and layout properties
  - .title class with gradient background and typography styles
  - .p-home__hero--name for hero name styling
  - .p-home__hero--role p for role text styling
  - .p-home__heroes--list with responsive positioning

The functionality remains the same while improving code maintainability by separating concerns between HTML structure and CSS styling.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9d51686926a64ec2a1cc073b0ef10471/pulse-den)

👀 [Preview Link](https://9d51686926a64ec2a1cc073b0ef10471-pulse-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9d51686926a64ec2a1cc073b0ef10471</projectId>-->
<!--<branchName>pulse-den</branchName>-->