### PR TITLE
Add inline styles to heroes bar and search components

### DIFF
--- a/src/GameplaySection.js
+++ b/src/GameplaySection.js
@@ -282,13 +282,15 @@ const GameplaySection = () => {
               <ul
                 className="st-heroes__types"
                 style={{
-                  display: "flex",
+                  display: "flex !important",
                   alignItems: "center",
                   margin: 0,
                   padding: 0,
                   listStyle: "none",
-                  flexWrap: "nowrap",
+                  flexWrap: "nowrap !important",
                   gap: "10px",
+                  whiteSpace: "nowrap",
+                  flexDirection: "row !important",
                 }}
               >
                 <li>


### PR DESCRIPTION
Add inline CSS styles to the heroes bar and search components in GameplaySection.js:

- Apply flexbox layout styles to st-heroes__bar div with space-between justification, center alignment, and specific font/margin properties
- Add flex display and center alignment styles to search div
- Apply flexbox styles to st-heroes__types ul with center alignment, no margin/padding, hidden list style, and nowrap flex direction

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/30e0bb0f115943ae842f82d3a58d4e15/orbit-home)

👀 [Preview Link](https://30e0bb0f115943ae842f82d3a58d4e15-orbit-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>30e0bb0f115943ae842f82d3a58d4e15</projectId>-->
<!--<branchName>orbit-home</branchName>-->