### PR TITLE
Update hero grid layout and add 8 new heroes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -689,8 +689,8 @@
 
 .st-heroes__list {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(70px, 1fr));
-  gap: 0.5rem;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 0.8rem;
   justify-items: center;
   background-color: rgba(0, 0, 0, 1);
 }

--- a/src/App.css
+++ b/src/App.css
@@ -825,7 +825,7 @@
   }
 
   .st-heroes__list {
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    grid-template-columns: repeat(4, 1fr);
     gap: 1rem;
   }
 

--- a/src/GameplaySection.js
+++ b/src/GameplaySection.js
@@ -142,6 +142,62 @@ const GameplaySection = () => {
         "https://lienquan.garena.vn/wp-content/uploads/2024/05/7f04b1fd7f0520dd1ccbd1caad6faf1a5847d3f72e85b1.png",
       link: "https://lienquan.garena.vn/hoc-vien/tuong-skin/d/krixi/",
     },
+    {
+      name: "Bijan",
+      type: [28],
+      image:
+        "https://lienquan.garena.vn/wp-content/uploads/2024/05/856d30cb10953b9480dce5c5470bf81c658d50d87305a1.jpg",
+      link: "https://lienquan.garena.vn/hoc-vien/tuong-skin/d/bijan/",
+    },
+    {
+      name: "Bonnie",
+      type: [29],
+      image:
+        "https://lienquan.garena.vn/wp-content/uploads/2024/05/a2ed1b1815df9c719e4f9b4be5eb3a74658d4cd7d3ef61.jpg",
+      link: "https://lienquan.garena.vn/hoc-vien/tuong-skin/d/bonnie/",
+    },
+    {
+      name: "Teeri",
+      type: [33],
+      image:
+        "https://lienquan.garena.vn/wp-content/uploads/2024/05/3499773a79087475e48194e0fd02e27d658d428c2cbe51.jpg",
+      link: "https://lienquan.garena.vn/hoc-vien/tuong-skin/d/teeri/",
+    },
+    {
+      name: "Yue",
+      type: [29],
+      image:
+        "https://lienquan.garena.vn/wp-content/uploads/2024/05/3ee26051086fee856dc6df74811e9e35658d4142ce14c1.jpg",
+      link: "https://lienquan.garena.vn/hoc-vien/tuong-skin/d/yue/",
+    },
+    {
+      name: "Yan",
+      type: [28],
+      image:
+        "https://lienquan.garena.vn/wp-content/uploads/2024/05/f9471319a98fac8dce266dc86cd1efea658d4042ae0051.jpg",
+      link: "https://lienquan.garena.vn/hoc-vien/tuong-skin/d/yan/",
+    },
+    {
+      name: "Aya",
+      type: [30],
+      image:
+        "https://lienquan.garena.vn/wp-content/uploads/2024/05/d4510fa53f153c5e259543597c96bb88658d3efcbcd0f1.jpg",
+      link: "https://lienquan.garena.vn/hoc-vien/tuong-skin/d/aya/",
+    },
+    {
+      name: "Aoi",
+      type: [32],
+      image:
+        "https://lienquan.garena.vn/wp-content/uploads/2024/05/f1db425eba8ea88e5d4d8427c1706bcf6100183de1cc11.jpeg",
+      link: "https://lienquan.garena.vn/hoc-vien/tuong-skin/d/aoi/",
+    },
+    {
+      name: "Iggy",
+      type: [29],
+      image:
+        "https://lienquan.garena.vn/wp-content/uploads/2024/05/b4563fbfd5756caeea04b7ef488ee39f60fffd803e9ab1.jpeg",
+      link: "https://lienquan.garena.vn/hoc-vien/tuong-skin/d/iggy/",
+    },
   ];
 
   const filteredHeroes = heroes.filter((hero) => {


### PR DESCRIPTION
This pull request makes the following changes:

**CSS Updates:**
- Changed hero grid from auto-fill layout to fixed 8 columns on desktop
- Increased gap from 0.5rem to 0.8rem for better spacing
- Updated responsive layout to use 4 fixed columns instead of auto-fill with 150px minimum

**New Heroes Added:**
- Bijan (type 28)
- Bonnie (type 29) 
- Teeri (type 33)
- Yue (type 29)
- Yan (type 28)
- Aya (type 30)
- Aoi (type 32)
- Iggy (type 29)

All new heroes include name, type classification, image URL, and link to their respective pages on the Garena website.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6eaf5bc59b744c43b09609164f089351/zenith-home)

👀 [Preview Link](https://6eaf5bc59b744c43b09609164f089351-zenith-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6eaf5bc59b744c43b09609164f089351</projectId>-->
<!--<branchName>zenith-home</branchName>-->